### PR TITLE
Fix bolt plan failures

### DIFF
--- a/lib/puppet-debugger/support.rb
+++ b/lib/puppet-debugger/support.rb
@@ -150,8 +150,13 @@ module PuppetDebugger
           require 'bolt/puppetdb'
           require 'bolt/puppetdb/client'
           require 'bolt/puppetdb/config'
-          config = Bolt::PuppetDB::Config.load_config({})
-          Bolt::PuppetDB::Client.new(config)
+          if Bolt::PuppetDB::Config.respond_to?(:default_config)
+            config = Bolt::PuppetDB::Config.default_config
+            Bolt::PuppetDB::Client.new(config: config)
+          else
+            config = Bolt::PuppetDB::Config.load_config({})
+            Bolt::PuppetDB::Client.new(config)
+          end
         rescue LoadError
           # not puppet 6+
           nil

--- a/puppet-debugger.gemspec
+++ b/puppet-debugger.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   # s.add_runtime_dependency('bolt', ['>= 2.42.0'])
   s.add_runtime_dependency('rb-readline', ['>= 0.5.5'])
   s.add_runtime_dependency('table_print', ['>= 1.0.0'])
-  s.add_runtime_dependency('tty-pager', ['~> 0.13.0'])
+  s.add_runtime_dependency('tty-pager', ['~> 0.13'])
   s.add_development_dependency('rdoc', ['~> 3.12'])
   s.add_development_dependency('rspec', ['~> 3.6'])
 end


### PR DESCRIPTION
Starting with Bolt 3.23.0, running a plan with  `debug::break()`  fails after entering any DSL expression with an error like `undefined method load_config' for Bolt::PuppetDB::Config:Class` .  This happens because puppetlabs/bolt#3092 changed the internal API of `Bolt::PuppetDB::Config`, including [dropping `load_config` and changing constructor parameters][0] .

This patch fixes the problem by updating the code to use the new API, too.  If the `load_config` method is available,  it will initialize the PuppetDB client the old way and preserve backward-compatibility with Bolt < 3.23. 

The constraints fix from #73 is included to allow Bolt plans using `puppet-debugger` to run without failing on gem conflicts. 

[0]: https://github.com/puppetlabs/bolt/commit/28448dc551bee8689cb15fb3c56748081b096330#diff-880143c89f3bfe37d46013a862f4a5a13e9166a278e5193292911c1530a12201